### PR TITLE
(SIMP-1169) Add RuboCop, fix for failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,28 @@
+---
+inherit_from: .rubocop_todo.yml
+inherit_from: .rubocop_1.8.yml
+
+AllCops:
+  TargetRubyVersion: 1.9
+  Exclude:
+    # Ignore HTML related things
+    - '**/*.erb'
+    # Ignore vendored gems
+    - 'vendor/**/*'
+    # Ignore code from test fixtures
+    - 'spec/fixtures/**/*'
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+
+# Follow the Puppet Style Guide for trailing commas
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+# XXX: Use non-Puppet style for `Style/TrailingCommaInArguments` to maintain compatability with Ruby 1.8
+#Style/TrailingCommaInArguments:
+#  EnforcedStyleForMultiline: comma
+
+# Use the line lenght specified in the Puppet Sytle Guide
+Metrics/LineLength:
+  Max: 140

--- a/.rubocop_1.8.yml
+++ b/.rubocop_1.8.yml
@@ -1,0 +1,7 @@
+---
+# Until Ruby 1.8 support is dropped...
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/DotPosition:
+  EnforcedStyle: trailing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+before_install: rm Gemfile.lock || true
+script:
+  - 'bundle exec rubocop'
+rvm:
+  - 2.2.5
+matrix:
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,30 +1,31 @@
 # Variables:
 #
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
+# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'].to_s : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem "rake"
+  gem 'rake'
+  gem 'rubocop', :require => false
   gem 'puppet', puppetversion
-  gem "rspec", '< 3.2.0'
-  gem "rspec-puppet"
-  gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
-  gem "simp-rspec-puppet-facts"
+  gem 'rspec', '< 3.2.0'
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'simp-rspec-puppet-facts'
 
   gem 'modulesync'
   # # dependency hacks:
-  # gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
+  # gem 'fog-google', '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # # simp-rake-helpers does not suport puppet 2.7.X
-  # if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+  # if ENV['PUPPET_VERSION'].to_s.scan(/\d+/).first != '2' &&
   #     # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
   #     # TODO: fix upstream deps (parallel in simp-rake-helpers)
-  #     RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+  #     RUBY_VERSION.sub(/\.\d+$/, '') != '1.8'
   #   gem 'simp-rake-helpers'
   # end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,16 @@
 require 'rake/clean'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
 
 CLEAN   << 'modules'
 CLOBBER << 'modules'
 
-        desc <<-EOM
+desc <<-EOM
         Download everything into `modules/` & whack in common assets.
             * :jira_issue - The Jira Issue (e.g., "SIMP-###") for this update.
         EOM
-task :suck, [:jira_issue] => [:clean] do |t, args|
-  fail 'The JIRA issue (e.g., "SIMP-###") is required!' unless args.jira_issue
+task :suck, [:jira_issue] => [:clean] do |_, args|
+  raise 'The JIRA issue (e.g., "SIMP-###") is required!' unless args.jira_issue
   sh "msync update --noop --branch #{args[:jira_issue]}"
 end

--- a/moduleroot/.rubocop.yml
+++ b/moduleroot/.rubocop.yml
@@ -1,0 +1,32 @@
+---
+inherit_from: .rubocop_todo.yml
+inherit_from: .rubocop_1.8.yml
+
+AllCops:
+  TargetRubyVersion: 1.9
+  Exclude:
+    # Ignore HTML related things
+    - '**/*.erb'
+    # Ignore vendored gems
+    - 'vendor/**/*'
+    # Ignore code from test fixtures
+    - 'spec/fixtures/**/*'
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+
+# Follow the Puppet Style Guide for trailing commas
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+# Except for argument lists where we need to maintain compatability with Ruby 1.8
+#Style/TrailingCommaInArguments:
+#  EnforcedStyleForMultiline: comma
+
+# Always prefer Puppet-style regex delimiters
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
+
+# Use the line lenght specified in the Puppet Sytle Guide
+Metrics/LineLength:
+  Max: 140

--- a/moduleroot/.rubocop_1.8.yml
+++ b/moduleroot/.rubocop_1.8.yml
@@ -1,0 +1,7 @@
+---
+# Until Ruby 1.8 support is dropped...
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/DotPosition:
+  EnforcedStyle: trailing

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -1,39 +1,42 @@
 # Variables:
 #
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
+# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'].to_s : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem "rake"
+  gem 'rake'
   gem 'puppet', puppetversion
-  gem "rspec", '< 3.2.0'
-  gem "rspec-puppet"
-  gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
-  gem "simp-rspec-puppet-facts"
+  gem 'rspec', '< 3.2.0'
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'simp-rspec-puppet-facts'
 
   # dependency hacks:
-  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
+  gem 'fog-google', '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
-  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
-      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
-      # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+  if ENV['PUPPET_VERSION'].to_s.scan(/\d+/).first != '2' &&
+     # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+     # TODO: fix upstream deps (parallel in simp-rake-helpers)
+     RUBY_VERSION.sub(/\.\d+$/, '') != '1.8'
     gem 'simp-rake-helpers'
+  end
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
+    gem 'rubocop', :require => false
   end
 end
 
 group :development do
-  gem "travis"
-  gem "travis-lint"
-  gem "vagrant-wrapper"
-  gem "puppet-blacksmith"
-  gem "guard-rake"
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'vagrant-wrapper'
+  gem 'puppet-blacksmith'
+  gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
 end

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -9,16 +9,21 @@ require 'puppet-lint/tasks/puppet-lint'
 begin
   require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
+  puts '== NOTICE: `puppet-blacksmith` not found. Install it to use the `module:` tasks. =='
 end
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+end
 
 # Lint & Syntax exclusions
 exclude_paths = [
-  "bundle/**/*",
-  "pkg/**/*",
-  "dist/**/*",
-  "vendor/**/*",
-  "spec/**/*",
+  'bundle/**/*',
+  'pkg/**/*',
+  'dist/**/*',
+  'vendor/**/*',
+  'spec/**/*',
 ]
 PuppetSyntax.exclude_paths = exclude_paths
 
@@ -31,35 +36,35 @@ end
 
 begin
   require 'simp/rake/pkg'
-  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+  Simp::Rake::Pkg.new(File.dirname(__FILE__)) do |t|
     t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
   end
 rescue LoadError
-  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
+  puts '== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =='
 end
 
 begin
   require 'simp/rake/beaker'
-  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
-rescue LoadError
+  Simp::Rake::Beaker.new(File.dirname(__FILE__))
+rescue LoadError # rubocop:disable Lint/HandleExceptions
   # Ignoring this for now since all of these are currently convenience methods.
 end
 
-desc "Run acceptance tests"
+desc 'Run acceptance tests'
 RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc "Populate CONTRIBUTORS file"
+desc 'Populate CONTRIBUTORS file'
 task :contributors do
   system("git log --format='%aN' | sort -u > CONTRIBUTORS")
 end
 
 task :metadata do
-  sh "metadata-json-lint metadata.json"
+  sh 'metadata-json-lint metadata.json'
 end
 
-desc "Run syntax, lint, and spec tests."
+desc 'Run syntax, lint, and spec tests.'
 task :test => [
   :syntax,
   :lint,


### PR DESCRIPTION
This adds RuboCop and its Rake task to this repo, as well as to the
baseline modulesync configs, and fixes all RuboCop failures.
Additionally, for this repo, it adds RuboCop as a Travis-CI test.

A few minor changes were made to the RuboCop configuration.  Namely,
changes were made to maintain compatability with Ruby 1.8.7, because we
need to maintain compatability with RHEL/CentOS 5 & 6 until they reach
EOL.  A few other changes are set to adhere to the Puppet Style Guide
where the are conflicts-- for example, line length and end-of-line
commas.
